### PR TITLE
fix: change set arn detection from tools that emit colored output

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,5 @@
 'use strict'
-const CHGSET_ARN_RGX = /arn:aws:cloudformation:([^:]+):\d+:changeSet\/([^/]+)\/[^" \t\n]+/
+const CHGSET_ARN_RGX = /arn:aws:cloudformation:([^:]+):\d+:changeSet\/([a-zA-Z][-a-zA-Z0-9]*)\/[-a-zA-Z0-9:/]+/
 
 /**
  * @typedef {Object} ChangeSetInfo

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -48,6 +48,15 @@ describe('helpers module', function () {
       desc: 'whitespace only input',
       input: '\n',
       output: null
+    }, {
+      desc: 'text input with control characters',
+      // eslint-disable-next-line no-tabs
+      input: 'arn:aws:cloudformation:eu-west-1:000000000000:changeSet/test/c785c2b0-63fc-11e7-94dc-500c423e34d2\x1B[0m\n',
+      output: {
+        arn: 'arn:aws:cloudformation:eu-west-1:000000000000:changeSet/test/c785c2b0-63fc-11e7-94dc-500c423e34d2',
+        region: 'eu-west-1',
+        name: 'test'
+      }
     }]
 
     cases.forEach(function (test) {


### PR DESCRIPTION
Improved regular expression to detect and parse change set arns will not match any terminal control characters (like colors) present in the input. This fixes an issue where change set arn emitted with colors could not be reviewed and parsed correctly.