### PR TITLE
fix: sso credential resolution for sso_session enabled source profiles

### DIFF
--- a/lib/cfn.js
+++ b/lib/cfn.js
@@ -5,7 +5,35 @@ const {
   DescribeStacksCommand,
   ExecuteChangeSetCommand
 } = require('@aws-sdk/client-cloudformation')
+
 const helpers = require('./helpers')
+
+// Workaround for https://github.com/aws/aws-sdk-js-v3/issues/4757.
+//
+// resolveProfileData is unable to resolve credentials for an SSO profile that uses the sso_session
+// option. This is because resolveProfileData does not resolve parameteters from the linked
+// sso-session.
+//
+// Here we monkeypatch the resolveProfileData method, catch errors that occur during its execution
+// and check if the error looks sso_session related. If so, we try to load credentials for the profile
+// with the fromSSO() method that also loads parameters from the linked sso-session.
+const { fromSSO } = require('@aws-sdk/credential-provider-sso')
+const resolveProfileDataModule = require('@aws-sdk/credential-provider-ini/dist-cjs/resolveProfileData.js')
+const resolveProfileData = resolveProfileDataModule.resolveProfileData
+resolveProfileDataModule.resolveProfileData = async (profileName, profiles, options, visitedProfiles = {}) => {
+  try {
+    return (await resolveProfileData(profileName, profiles, options, visitedProfiles))
+  } catch (e) {
+    if (/Profile is configured with invalid SSO credentials. Required parameters/.test(e.message)) {
+      // resolveProfileData() failed as an SSO profile profile being an SSO profile with some parameters being
+      // defined via sso-session. Try to load credentials with fromSSO() instead as that can resolve
+      // parameters from the linked sso-session.
+      return fromSSO({ profile: profileName })()
+    }
+
+    throw e
+  }
+}
 
 /**
  * Describe the given changeset & stack. Waits for creation to complete

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-cloudformation": "^3.46.0",
+        "@aws-sdk/client-cloudformation": "3.454.0",
+        "@aws-sdk/credential-provider-ini": "3.451.0",
+        "@aws-sdk/credential-provider-sso": "3.451.0",
         "chalk": "^4.1.2",
         "lodash.groupby": "^4.6.0",
         "ttys": "0.0.3"
@@ -128,49 +130,49 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-cloudformation": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.449.0.tgz",
-      "integrity": "sha512-Hk2i0BWfc0IpmTCKPl5UtSnPlueaJkhXNL27F7teAqpTyPOBh5xjkxxd6KjnIhcM01PcSoO5iu7f2+6OYA7uqw==",
+      "version": "3.454.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.454.0.tgz",
+      "integrity": "sha512-CKOE5u2gLt/BjHYX6a0uKGsWPBic9uOzlTwqnpqXEmVSb25xv5ULHOUmYfmSyw2TWXwxEe4a6ZwBL0MYJGrEUw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.449.0",
-        "@aws-sdk/core": "3.445.0",
-        "@aws-sdk/credential-provider-node": "3.449.0",
-        "@aws-sdk/middleware-host-header": "3.449.0",
-        "@aws-sdk/middleware-logger": "3.449.0",
-        "@aws-sdk/middleware-recursion-detection": "3.449.0",
-        "@aws-sdk/middleware-signing": "3.449.0",
-        "@aws-sdk/middleware-user-agent": "3.449.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.449.0",
-        "@aws-sdk/util-endpoints": "3.449.0",
-        "@aws-sdk/util-user-agent-browser": "3.449.0",
-        "@aws-sdk/util-user-agent-node": "3.449.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
+        "@aws-sdk/client-sts": "3.454.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-signing": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.12",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/util-waiter": "^2.0.13",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
@@ -180,45 +182,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.449.0.tgz",
-      "integrity": "sha512-HFTlFbf9jwp5BJkXbMKlEwk6oGC7AVYaPEkaNk77kzZ8RGoqVSAqe0HL74DACcJUpMD/VWYX7pfWq/Wm+2B79g==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.451.0.tgz",
+      "integrity": "sha512-KkYSke3Pdv3MfVH/5fT528+MKjMyPKlcLcd4zQb0x6/7Bl7EHrPh1JZYjzPLHelb+UY5X0qN8+cb8iSu1eiwIQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.445.0",
-        "@aws-sdk/middleware-host-header": "3.449.0",
-        "@aws-sdk/middleware-logger": "3.449.0",
-        "@aws-sdk/middleware-recursion-detection": "3.449.0",
-        "@aws-sdk/middleware-user-agent": "3.449.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.449.0",
-        "@aws-sdk/util-endpoints": "3.449.0",
-        "@aws-sdk/util-user-agent-browser": "3.449.0",
-        "@aws-sdk/util-user-agent-node": "3.449.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -226,48 +228,48 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.449.0.tgz",
-      "integrity": "sha512-iKh5Es9tyY+Ch17bvMubW67ydW4X3Buy9vwTIqpmXlnXEfbvjZRwycjWK2MO/P1Su3wjA14zNBq2ifNWFxkwFA==",
+      "version": "3.454.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.454.0.tgz",
+      "integrity": "sha512-0fDvr8WeB6IYO8BUCzcivWmahgGl/zDbaYfakzGnt4mrl5ztYaXE875WI6b7+oFcKMRvN+KLvwu5TtyFuNY+GQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.445.0",
-        "@aws-sdk/credential-provider-node": "3.449.0",
-        "@aws-sdk/middleware-host-header": "3.449.0",
-        "@aws-sdk/middleware-logger": "3.449.0",
-        "@aws-sdk/middleware-recursion-detection": "3.449.0",
-        "@aws-sdk/middleware-sdk-sts": "3.449.0",
-        "@aws-sdk/middleware-signing": "3.449.0",
-        "@aws-sdk/middleware-user-agent": "3.449.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.449.0",
-        "@aws-sdk/util-endpoints": "3.449.0",
-        "@aws-sdk/util-user-agent-browser": "3.449.0",
-        "@aws-sdk/util-user-agent-node": "3.449.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-sdk-sts": "3.451.0",
+        "@aws-sdk/middleware-signing": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -276,11 +278,11 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.445.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.445.0.tgz",
-      "integrity": "sha512-6GYLElUG1QTOdmXG8zXa+Ull9IUeSeItKDYHKzHYfIkbsagMfYlf7wm9XIYlatjtgodNfZ3gPHAJfRyPmwKrsg==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.451.0.tgz",
+      "integrity": "sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==",
       "dependencies": {
-        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/smithy-client": "^2.1.15",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -288,13 +290,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.449.0.tgz",
-      "integrity": "sha512-SwO9XQcBoyA0XrsSmgnMqCnR99wIyp+BjGhvzDU+Wetib7QPt++E2slJkLM/iCNc6YiqiHZtHsvXapSV7RzBJw==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.451.0.tgz",
+      "integrity": "sha512-9dAav7DcRgaF7xCJEQR5ER9ErXxnu/tdnVJ+UPmb1NPeIZdESv1A3lxFDEq1Fs8c4/lzAj9BpshGyJVIZwZDKg==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -302,19 +304,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.449.0.tgz",
-      "integrity": "sha512-C2pMYysIfbRBR4Q+Aj7J0cRsKY/X2cOnrggrWzsEUJK3EJ1aHwrzm3HI0VM5DttJyya5hE4tZ/H1VX3zNGUtKA==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.451.0.tgz",
+      "integrity": "sha512-TySt64Ci5/ZbqFw1F9Z0FIGvYx5JSC9e6gqDnizIYd8eMnn8wFRUscRrD7pIHKfrhvVKN5h0GdYovmMO/FMCBw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.449.0",
-        "@aws-sdk/credential-provider-process": "3.449.0",
-        "@aws-sdk/credential-provider-sso": "3.449.0",
-        "@aws-sdk/credential-provider-web-identity": "3.449.0",
-        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/credential-provider-env": "3.451.0",
+        "@aws-sdk/credential-provider-process": "3.451.0",
+        "@aws-sdk/credential-provider-sso": "3.451.0",
+        "@aws-sdk/credential-provider-web-identity": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -322,20 +324,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.449.0.tgz",
-      "integrity": "sha512-cCsqMqL8vmHADwIHCmTWDB4vr5fCXb4PZn3njbA/PIA92xL4S7hRmYi/1ll0CMd+fks+t/h+s+PIhFGo54C7cA==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.451.0.tgz",
+      "integrity": "sha512-AEwM1WPyxUdKrKyUsKyFqqRFGU70e4qlDyrtBxJnSU9NRLZI8tfEZ67bN7fHSxBUBODgDXpMSlSvJiBLh5/3pw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.449.0",
-        "@aws-sdk/credential-provider-ini": "3.449.0",
-        "@aws-sdk/credential-provider-process": "3.449.0",
-        "@aws-sdk/credential-provider-sso": "3.449.0",
-        "@aws-sdk/credential-provider-web-identity": "3.449.0",
-        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/credential-provider-env": "3.451.0",
+        "@aws-sdk/credential-provider-ini": "3.451.0",
+        "@aws-sdk/credential-provider-process": "3.451.0",
+        "@aws-sdk/credential-provider-sso": "3.451.0",
+        "@aws-sdk/credential-provider-web-identity": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -343,14 +345,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.449.0.tgz",
-      "integrity": "sha512-IofhAgpwdSnaEg9H0dhydac07GCQ55Mc5oRzdzp/tm0Rl0MqnGdIvN8wYsxAeVhEi9pBSNla4eRiTu3LY6Z5+A==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.451.0.tgz",
+      "integrity": "sha512-HQywSdKeD5PErcLLnZfSyCJO+6T+ZyzF+Lm/QgscSC+CbSUSIPi//s15qhBRVely/3KBV6AywxwNH+5eYgt4lQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -358,16 +360,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.449.0.tgz",
-      "integrity": "sha512-Lfhh38rOjFAZBjZZJ2ehve+X048xxr+hTr+ntGOKady1GAH6W1U5UGNYuD9fr5vFaQQtAcNLKkUui+TnmJ4z/w==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.451.0.tgz",
+      "integrity": "sha512-Usm/N51+unOt8ID4HnQzxIjUJDrkAQ1vyTOC0gSEEJ7h64NSSPGD5yhN7il5WcErtRd3EEtT1a8/GTC5TdBctg==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.449.0",
-        "@aws-sdk/token-providers": "3.449.0",
-        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/client-sso": "3.451.0",
+        "@aws-sdk/token-providers": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -375,13 +377,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.449.0.tgz",
-      "integrity": "sha512-BdqATzdqg39z2VXnEH7I6dzuX/Di6F/4C8FyiiJYx2+VciYdqt6GPprlpGdpngtWct/f8pA/LxQysNBVuwU/RA==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.451.0.tgz",
+      "integrity": "sha512-Xtg3Qw65EfDjWNG7o2xD6sEmumPfsy3WDGjk2phEzVg8s7hcZGxf5wYwe6UY7RJvlEKrU0rFA+AMn6Hfj5oOzg==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -389,13 +391,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.449.0.tgz",
-      "integrity": "sha512-uO7ao5eFhqEEPk8uqkhNhYqqJPPv/+i2aLchvSYrviDcmcbz9HURc8j+Q9WkmIj3jf0hjAJ9UVMQggBUfoLEgg==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.451.0.tgz",
+      "integrity": "sha512-j8a5jAfhWmsK99i2k8oR8zzQgXrsJtgrLxc3js6U+525mcZytoiDndkWTmD5fjJ1byU1U2E5TaPq+QJeDip05Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -403,12 +405,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.449.0.tgz",
-      "integrity": "sha512-YwmPLuSx5Zjdnloxr7bArT2KgF+VvlSe5+p5T/woZWEQgINRaCLdvDB37p7x/LlHrxxZRmk20MaFwSKlJU85qQ==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.451.0.tgz",
+      "integrity": "sha512-0kHrYEyVeB2QBfP6TfbI240aRtatLZtcErJbhpiNUb+CQPgEL3crIjgVE8yYiJumZ7f0jyjo8HLPkwD1/2APaw==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -416,13 +418,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.449.0.tgz",
-      "integrity": "sha512-8kWxxpPBHwFUADf8JaZsUbJ+FtS3K9MGQpMx0AZhh3P9xLaoh602CL0y0+UEEdb2uh6FJJjQiIk4eQXEolhG6Q==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.451.0.tgz",
+      "integrity": "sha512-J6jL6gJ7orjHGM70KDRcCP7so/J2SnkN4vZ9YRLTeeZY6zvBuHDjX8GCIgSqPn/nXFXckZO8XSnA7u6+3TAT0w==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -430,13 +432,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.449.0.tgz",
-      "integrity": "sha512-a+mknJkS9jDiDoHg2sFW24B0f6MgT2zs/oF6zMFvVmImvUHjbhSgBzYStE+Phl/uM1zwp1lJfbuO+I+5tVwZEw==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.451.0.tgz",
+      "integrity": "sha512-UJ6UfVUEgp0KIztxpAeelPXI5MLj9wUtUCqYeIMP7C1ZhoEMNm3G39VLkGN43dNhBf1LqjsV9jkKMZbVfYXuwg==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.449.0",
-        "@aws-sdk/types": "3.449.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/middleware-signing": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -444,16 +446,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.449.0.tgz",
-      "integrity": "sha512-L33efrgdDDY3myjLwraeS2tzUlebaZL6WS7ooACsOwkB9mRs6UQRpSpT90HbcSAjwLaa+xGqaxTA0biAuRjT5A==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.451.0.tgz",
+      "integrity": "sha512-s5ZlcIoLNg1Huj4Qp06iKniE8nJt/Pj1B/fjhWc6cCPCM7XJYUCejCnRh6C5ZJoBEYodjuwZBejPc1Wh3j+znA==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/types": "3.451.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/protocol-http": "^3.0.9",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-middleware": "^2.0.6",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -461,14 +463,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.449.0.tgz",
-      "integrity": "sha512-0cRptIhIthxUYadrgb5FmcTgGhPIeXnFATBILaa2gA/ivfVY/CiqMAvOvLHxtBAYNK8/VXM9DFL5TfOt8mF2UQ==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.451.0.tgz",
+      "integrity": "sha512-8NM/0JiKLNvT9wtAQVl1DFW0cEO7OvZyLSUBLNLTHqyvOZxKaZ8YFk7d8PL6l76LeUKRxq4NMxfZQlUIRe0eSA==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
-        "@aws-sdk/util-endpoints": "3.449.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -476,14 +478,14 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.433.0.tgz",
-      "integrity": "sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.451.0.tgz",
+      "integrity": "sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
         "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/util-middleware": "^2.0.6",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -491,46 +493,46 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.449.0.tgz",
-      "integrity": "sha512-Tgu6Z/l75uFuNQpKIidbn1gc5bI7OKmGdH5+E/ZAc58XYvxYs9N77HjhrhAGvYQEnXY6gRm26/WSeHAAh5wlgQ==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.451.0.tgz",
+      "integrity": "sha512-ij1L5iUbn6CwxVOT1PG4NFjsrsKN9c4N1YEM0lkl6DwmaNOscjLKGSNyj9M118vSWsOs1ZDbTwtj++h0O/BWrQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.449.0",
-        "@aws-sdk/middleware-logger": "3.449.0",
-        "@aws-sdk/middleware-recursion-detection": "3.449.0",
-        "@aws-sdk/middleware-user-agent": "3.449.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.449.0",
-        "@aws-sdk/util-endpoints": "3.449.0",
-        "@aws-sdk/util-user-agent-browser": "3.449.0",
-        "@aws-sdk/util-user-agent-node": "3.449.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/protocol-http": "^3.0.9",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -538,11 +540,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.449.0.tgz",
-      "integrity": "sha512-tSQPAvknheB6XnRoc+AuEgdzn2KhY447hddeVW0Mbg8Yl9es4u4TKVINloKDEyUrCKhB/1f93Hb5uJkPe/e/Ww==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.451.0.tgz",
+      "integrity": "sha512-rhK+qeYwCIs+laJfWCcrYEjay2FR/9VABZJ2NRM89jV/fKqGVQR52E5DQqrI+oEIL5JHMhhnr4N4fyECMS35lw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -550,12 +552,12 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.449.0.tgz",
-      "integrity": "sha512-hWGM/e+BnbCExXLaIEa6gRb0JW3+XGfcHgRqWkAxsKCaxQuXVIPUA3HyifimxTZDKmTbGZcyWfxCnKGS7I19rw==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.451.0.tgz",
+      "integrity": "sha512-giqLGBTnRIcKkDqwU7+GQhKbtJ5Ku35cjGQIfMyOga6pwTBUbaK0xW1Sdd8sBQ1GhApscnChzI9o/R9x0368vw==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
-        "@smithy/util-endpoints": "^1.0.2",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/util-endpoints": "^1.0.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -574,24 +576,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.449.0.tgz",
-      "integrity": "sha512-MUQ8YIVZNZZso5w1qlatHu9c1JKYvdjlAugzKhj7npgV4U8D9RBOJUd2Ct8meXPaH4DTfW1qohPlZu/fWWqNVQ==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.451.0.tgz",
+      "integrity": "sha512-Ws5mG3J0TQifH7OTcMrCTexo7HeSAc3cBgjfhS/ofzPUzVCtsyg0G7I6T7wl7vJJETix2Kst2cpOsxygPgPD9w==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/types": "^2.5.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.449.0.tgz",
-      "integrity": "sha512-PFMnFMSQTdhMAS63anMFFkzz56kWKcjGscgl0bBheEaxo8zgfLf1AAdFuBM+Ob2KYXeMezUbxYu9zOC/0S2hvw==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.451.0.tgz",
+      "integrity": "sha512-TBzm6P+ql4mkGFAjPlO1CI+w3yUT+NulaiALjl/jNX/nnUp6HsJsVxJf4nVFQTG5KRV0iqMypcs7I3KIhH+LmA==",
       "dependencies": {
-        "@aws-sdk/types": "3.449.0",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.451.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -823,11 +825,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
-      "integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.13.tgz",
+      "integrity": "sha512-eeOPD+GF9BzF/Mjy3PICLePx4l0f3rG/nQegQHRLTloN5p1lSJJNZsyn+FzDnW8P2AduragZqJdtKNCxXozB1Q==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -835,14 +837,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.17.tgz",
-      "integrity": "sha512-iQ8Q8ojqiPqRKdybDI1g7HvG8EcnekRnH3DYeNTrT26vDuPq2nomyMCc0DZnPW+uAUcLCGZpAmGTAvEOYX55wA==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.18.tgz",
+      "integrity": "sha512-761sJSgNbvsqcsKW6/WZbrZr4H+0Vp/QKKqwyrxCPwD8BsiPEXNHyYnqNgaeK9xRWYswjon0Uxbpe3DWQo0j/g==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/types": "^2.4.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
         "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/util-middleware": "^2.0.6",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -850,14 +852,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.0.tgz",
-      "integrity": "sha512-amqeueHM3i02S6z35WlXp7gejBnRloT5ctR/mQLlg/6LWGd70Avc2epzuuWtCptNg2ak5/yODD1fAVs9NPCyqg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.1.tgz",
+      "integrity": "sha512-gw5G3FjWC6sNz8zpOJgPpH5HGKrpoVFQpToNAwLwJVyI/LJ2jDJRjSKEsM6XI25aRpYjMSE/Qptxx305gN1vHw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/property-provider": "^2.0.14",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -865,34 +867,34 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.12.tgz",
-      "integrity": "sha512-ZZQLzHBJkbiAAdj2C5K+lBlYp/XJ+eH2uy+jgJgYIFW/o5AM59Hlj7zyI44/ZTDIQWmBxb3EFv/c5t44V8/g8A==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.13.tgz",
+      "integrity": "sha512-CExbelIYp+DxAHG8RIs0l9QL7ElqhG4ym9BNoSpkPa4ptBQfzJdep3LbOSVJIE2VUdBAeObdeL6EDB3Jo85n3g==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "@smithy/util-hex-encoding": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.5.tgz",
-      "integrity": "sha512-m9yoTx+64XRSpCzWArOpvHeAuVfI2LFz2hDzgzjzCLlN8IIwzkFaCav5ShsYxx4iu9sXp09+on0a5VROY9+MFQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.6.tgz",
+      "integrity": "sha512-PStY3XO1Ksjwn3wMKye5U6m6zxXpXrXZYqLy/IeCbh3nM9QB3Jgw/B0PUSLUWKdXg4U8qgEu300e3ZoBvZLsDg==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/querystring-builder": "^2.0.13",
+        "@smithy/types": "^2.5.0",
         "@smithy/util-base64": "^2.0.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.14.tgz",
-      "integrity": "sha512-eS2Q4IE2AZDfrfpXma49M2H1NVcs7VFg2KZ5hndQZibCmFJehS9CjjwIu0aWC61p4sEB7jWXw70bzOllyQU6GQ==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.15.tgz",
+      "integrity": "sha512-t/qjEJZu/G46A22PAk1k/IiJZT4ncRkG5GOCNWN9HPPy5rCcSZUbh7gwp7CGKgJJ7ATMMg+0Td7i9o1lQTwOfQ==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
@@ -902,11 +904,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
-      "integrity": "sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.13.tgz",
+      "integrity": "sha512-XsGYhVhvEikX1Yz0kyIoLssJf2Rs6E0U2w2YuKdT4jSra5A/g8V2oLROC1s56NldbgnpesTYB2z55KCHHbKyjw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       }
     },
@@ -922,12 +924,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.14.tgz",
-      "integrity": "sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.15.tgz",
+      "integrity": "sha512-xH4kRBw01gJgWiU+/mNTrnyFXeozpZHw39gLb3JKGsFDVmSrJZ8/tRqu27tU/ki1gKkxr2wApu+dEYjI3QwV1Q==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -935,16 +937,16 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.5.tgz",
-      "integrity": "sha512-eRhI0mI9tnkpmLwJbprV+MdlPyOMe8tFtVrNFMUlgOQrJeYv5AD5UFRn/KhgNX1vO1pVgpPtD9R+cRuFhj/lIQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.0.tgz",
+      "integrity": "sha512-tddRmaig5URk2106PVMiNX6mc5BnKIKajHHDxb7K0J5MLdcuQluHMGnjkv18iY9s9O0tF+gAcPd/pDXA5L9DZw==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/shared-ini-file-loader": "^2.2.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/shared-ini-file-loader": "^2.2.4",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-middleware": "^2.0.6",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -952,16 +954,16 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.19.tgz",
-      "integrity": "sha512-VMS1GHxLpRnuLHrPTj/nb9aD99jJsNzWX07F00fIuV9lkz3lWP7RUM7P1aitm0+4YfhShPn+Wri8/CuoqPOziA==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.20.tgz",
+      "integrity": "sha512-X2yrF/SHDk2WDd8LflRNS955rlzQ9daz9UWSp15wW8KtzoTXg3bhHM78HbK1cjr48/FWERSJKh9AvRUUGlIawg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-retry": "^2.0.5",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/service-error-classification": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-middleware": "^2.0.6",
+        "@smithy/util-retry": "^2.0.6",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -970,11 +972,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
-      "integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.13.tgz",
+      "integrity": "sha512-tBGbeXw+XsE6pPr4UaXOh+UIcXARZeiA8bKJWxk2IjJcD1icVLhBSUQH9myCIZLNNzJIH36SDjUX8Wqk4xJCJg==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -982,11 +984,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
-      "integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.7.tgz",
+      "integrity": "sha512-L1KLAAWkXbGx1t2jjCI/mDJ2dDNq+rp4/ifr/HcC6FHngxho5O7A5bQLpKHGlkfATH6fUnOEx0VICEVFA4sUzw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -994,13 +996,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.4.tgz",
-      "integrity": "sha512-kROLnHFatpimtmZ8YefsRRb5OJ8LVIVNhUWp67KHL4D2Vjd+WpIHMzWtkLLV4p0qXpY+IxmwcL2d2XMPn8ppsQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.5.tgz",
+      "integrity": "sha512-3Omb5/h4tOCuKRx4p4pkYTvEYRCYoKk52bOYbKUyz/G/8gERbagsN8jFm4FjQubkrcIqQEghTpQaUw6uk+0edw==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/shared-ini-file-loader": "^2.2.3",
-        "@smithy/types": "^2.4.0",
+        "@smithy/property-provider": "^2.0.14",
+        "@smithy/shared-ini-file-loader": "^2.2.4",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1008,14 +1010,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
-      "integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.9.tgz",
+      "integrity": "sha512-+K0q3SlNcocmo9OZj+fz67gY4lwhOCvIJxVbo/xH+hfWObvaxrMTx7JEzzXcluK0thnnLz++K3Qe7Z/8MDUreA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/abort-controller": "^2.0.13",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/querystring-builder": "^2.0.13",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1023,11 +1025,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
-      "integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.14.tgz",
+      "integrity": "sha512-k3D2qp9o6imTrLaXRj6GdLYEJr1sXqS99nLhzq8fYmJjSVOeMg/G+1KVAAc7Oxpu71rlZ2f8SSZxcSxkevuR0A==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1035,11 +1037,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.9.tgz",
+      "integrity": "sha512-U1wl+FhYu4/BC+rjwh1lg2gcJChQhytiNQSggREgQ9G2FzmoK9sACBZvx7thyWMvRyHQTE22mO2d5UM8gMKDBg==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1047,11 +1049,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
-      "integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.13.tgz",
+      "integrity": "sha512-JhXKwp3JtsFUe96XLHy/nUPEbaXqn6r7xE4sNaH8bxEyytE5q1fwt0ew/Ke6+vIC7gP87HCHgQpJHg1X1jN2Fw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -1060,11 +1062,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
-      "integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.13.tgz",
+      "integrity": "sha512-TEiT6o8CPZVxJ44Rly/rrsATTQsE+b/nyBVzsYn2sa75xAaZcurNxsFd8z1haoUysONiyex24JMHoJY6iCfLdA==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1072,22 +1074,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.5.tgz",
-      "integrity": "sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.6.tgz",
+      "integrity": "sha512-fCQ36frtYra2fqY2/DV8+3/z2d0VB/1D1hXbjRcM5wkxTToxq6xHbIY/NGGY6v4carskMyG8FHACxgxturJ9Pg==",
       "dependencies": {
-        "@smithy/types": "^2.4.0"
+        "@smithy/types": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.3.tgz",
-      "integrity": "sha512-VDyhCNycPbNkPidMnBgYQeSwJkoATRFm5VrveVqIPAjsdGutf7yZpPycuDWW9bRFnuuwaBhCC0pA7KCH0+2wrg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.4.tgz",
+      "integrity": "sha512-9dRknGgvYlRIsoTcmMJXuoR/3ekhGwhRq4un3ns2/byre4Ql5hyUN4iS0x8eITohjU90YOnUCsbRwZRvCkbRfw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1095,15 +1097,15 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.14.tgz",
-      "integrity": "sha512-ZUU8gGlDVFyU3tM9tCEbq2FxHtyfX2qYBUKoIGH23GSxbC4+Ld/HeFL2EZYIFrYwoOuPBO30+g3fAohOP9Ax3Q==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.15.tgz",
+      "integrity": "sha512-SRTEJSEhQYVlBKIIdZ9SZpqW+KFqxqcNnEcBX+8xkDdWx+DItme9VcCDkdN32yTIrICC+irUufnUdV7mmHPjoA==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.12",
+        "@smithy/eventstream-codec": "^2.0.13",
         "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/util-middleware": "^2.0.6",
         "@smithy/util-uri-escape": "^2.0.0",
         "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
@@ -1113,13 +1115,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.14.tgz",
-      "integrity": "sha512-SMiflchpKadmyvjWPTVwBKjDcEigRHkiUjtzLBlTp9dEp2FmbCjpyc95BNvUdOGOMcPCIkoQQGeabo6avIZNiw==",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.15.tgz",
+      "integrity": "sha512-rngZcQu7Jvs9UbHihK1EI67RMPuzkc3CJmu4MBgB7D7yBnMGuFR86tq5rqHfL2gAkNnMelBN/8kzQVvZjNKefQ==",
       "dependencies": {
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-stream": "^2.0.19",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-stream": "^2.0.20",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1127,9 +1129,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-/a31lYofrMBkJb3BuPlYJTMKDj0hUmKUP6JFZQu6YVuQVoAjubiY0A52U9S0Uysd33n/djexCUSNJ+G9bf3/aA==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1138,12 +1140,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
-      "integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.13.tgz",
+      "integrity": "sha512-okWx2P/d9jcTsZWTVNnRMpFOE7fMkzloSFyM53fA7nLKJQObxM2T4JlZ5KitKKuXq7pxon9J6SF2kCwtdflIrA==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/querystring-parser": "^2.0.13",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       }
     },
@@ -1202,13 +1204,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.18.tgz",
-      "integrity": "sha512-Dok3alNbkKI3MGTiW9zYGY/1gmU0MgrUMk0aRuNOeypY1TuKJ4NuNAbq5dv1GnWvYeFzWk4j0FMIwpJLF8DVmg==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.19.tgz",
+      "integrity": "sha512-VHP8xdFR7/orpiABJwgoTB0t8Zhhwpf93gXhNfUBiwAE9O0rvsv7LwpQYjgvbOUDDO8JfIYQB2GYJNkqqGWsXw==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.14",
-        "@smithy/types": "^2.4.0",
+        "@smithy/property-provider": "^2.0.14",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -1217,16 +1219,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.24.tgz",
-      "integrity": "sha512-f5wM/SbjvDTCXxk//od43hhnEPItdZB3ByAqbpz5dkum/vLQe2hFRvMNbpt7UA4htQTrbUmLWJatUmvGQEFypg==",
+      "version": "2.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.25.tgz",
+      "integrity": "sha512-jkmep6/JyWmn2ADw9VULDeGbugR4N/FJCKOt+gYyVswmN1BJOfzF2umaYxQ1HhQDvna3kzm1Dbo1qIfBW4iuHA==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.17",
-        "@smithy/credential-provider-imds": "^2.1.0",
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.14",
-        "@smithy/types": "^2.4.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/credential-provider-imds": "^2.1.1",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/property-provider": "^2.0.14",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1234,12 +1236,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.3.tgz",
-      "integrity": "sha512-rMYXLMdAMVbJAEHhNlCSJsAxo3NG3lcPja7WmesjAbNrMSyYZ6FnHHTy8kzRhddn4eAtLvPBSO6LiBB21gCoHQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.4.tgz",
+      "integrity": "sha512-FPry8j1xye5yzrdnf4xKUXVnkQErxdN7bUIaqC0OFoGsv2NfD9b2UUMuZSSt+pr9a8XWAqj0HoyVNUfPiZ/PvQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/types": "^2.4.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1258,11 +1260,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.6.tgz",
+      "integrity": "sha512-7W4uuwBvSLgKoLC1x4LfeArCVcbuHdtVaC4g30kKsD1erfICyQ45+tFhhs/dZNeQg+w392fhunCm/+oCcb6BSA==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1270,12 +1272,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.5.tgz",
-      "integrity": "sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.6.tgz",
+      "integrity": "sha512-PSO41FofOBmyhPQJwBQJ6mVlaD7Sp9Uff9aBbnfBJ9eqXOE/obrqQjn0PNdkfdvViiPXl49BINfnGcFtSP4kYw==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
+        "@smithy/service-error-classification": "^2.0.6",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1283,13 +1285,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.19.tgz",
-      "integrity": "sha512-2kwTRyOKJcRFeO1LX4Qn1vniEyU1urMG1DfomTpiOLTFS0iV3dsqNvYNltvTbmzZd9u0f15H96l38QP8dsKF1w==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.20.tgz",
+      "integrity": "sha512-tT8VASuD8jJu0yjHEMTCPt1o5E3FVzgdsxK6FQLAjXKqVv5V8InCnc0EOsYrijgspbfDqdAJg7r0o2sySfcHVg==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.2.5",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/types": "^2.4.0",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/types": "^2.5.0",
         "@smithy/util-base64": "^2.0.1",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -1324,12 +1326,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.12.tgz",
-      "integrity": "sha512-3sENmyVa1NnOPoiT2NCApPmu7ukP7S/v7kL9IxNmnygkDldn7/yK0TP42oPJLwB2k3mospNsSePIlqdXEUyPHA==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.13.tgz",
+      "integrity": "sha512-YovIQatiuM7giEsRFotqJa2i3EbU2EE3PgtpXgtLgpx5rXiZMAwPxXYDFVFhuO0lbqvc/Zx4n+ZIisXOHPSqyg==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/abort-controller": "^2.0.13",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "license": "MIT",
   "repository": "sjakthol/cfn-execute-change-set",
   "dependencies": {
-    "@aws-sdk/client-cloudformation": "^3.46.0",
+    "@aws-sdk/client-cloudformation": "3.454.0",
+    "@aws-sdk/credential-provider-ini": "3.451.0",
+    "@aws-sdk/credential-provider-sso": "3.451.0",
     "chalk": "^4.1.2",
     "lodash.groupby": "^4.6.0",
     "ttys": "0.0.3"


### PR DESCRIPTION
AWS SDK JS v3 is unable to resolve credentials when a source_profile points to a profile using sso_session option:
https://github.com/aws/aws-sdk-js-v3/issues/4757.

This commit monkeypatches the problematic function, catches failure and tries to load credentials again using fromSSO() method that has more extensive logic for resolving credentials for SSO profiles.

Versions of involved packages have been pinned to exact versions to avoid sudden breakage if the methods in question change.